### PR TITLE
Profile Image Storing

### DIFF
--- a/backend/author/managers.py
+++ b/backend/author/managers.py
@@ -1,0 +1,37 @@
+from django.contrib.auth.models import BaseUserManager
+
+class AccountManager(BaseUserManager):
+    use_in_migrations = True
+
+    def _create_user(self, email, displayName, password, **extra_fields):
+        values = [email, displayName]
+        field_value_map = dict(zip(self.model.REQUIRED_FIELDS, values))
+        for field_name, value in field_value_map.items():
+            if not value:
+                raise ValueError('The {} value must be set'.format(field_name))
+
+        email = self.normalize_email(email)
+        user = self.model(
+            email=email,
+            displayName=displayName,
+            **extra_fields
+        )
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_user(self, email, displayName, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', False)
+        extra_fields.setdefault('is_superuser', False)
+        # extra_fields.setdefault('is_auth', False) # ADMIN MUST MANUALLY AUTHENTICATE
+        return self._create_user(email, displayName, password, **extra_fields)
+
+    def create_superuser(self, email, displayName, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+        return self._create_user(email, displayName, password, **extra_fields)

--- a/backend/author/models.py
+++ b/backend/author/models.py
@@ -1,66 +1,15 @@
+from statistics import mode
 from django.db import models
-from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
-from django.utils import timezone
+from .managers import AccountManager
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
+from django.db.models.signals import post_delete
+from django.dispatch.dispatcher import receiver
 import uuid
+import os
 
 # For when we have more setup, create upload location
 def upload_path(instance, filename):
-    return '/'.join(['profileImages', str(instance.id), filename])
-
-# class Author(models.Model):
-#     type = models.TextField(default="author")
-#     url = models.URLField(blank=True)
-#     host = models.URLField(blank=True )
-#     displayName = models.TextField()
-#     github = models.URLField()
-#         # profileImage = models.ImageField(blank=True, null=True, upload_to=upload_path) # Implement upload location later `upload_to=upload_path`
-
-
-#     #The following are used in Like app
-#     def __str__(self):
-#         return self.type+","+self.host+","+self.displayName+","+self.url+","+self.github
-
-#     def toString(self):
-#         return {"type: ":self.type,
-#                 "host: ":self.host,
-#                 "displayName: " :self.displayName,
-#                 "url: ": self.url,
-#                 "github: ":self.github}
-
-class AccountManager(BaseUserManager):
-    use_in_migrations = True
-
-    def _create_user(self, email, displayName, password, **extra_fields):
-        values = [email, displayName]
-        field_value_map = dict(zip(self.model.REQUIRED_FIELDS, values))
-        for field_name, value in field_value_map.items():
-            if not value:
-                raise ValueError('The {} value must be set'.format(field_name))
-
-        email = self.normalize_email(email)
-        user = self.model(
-            email=email,
-            displayName=displayName,
-            **extra_fields
-        )
-        user.set_password(password)
-        user.save(using=self._db)
-        return user
-
-    def create_user(self, email, displayName, password=None, **extra_fields):
-        extra_fields.setdefault('is_staff', False)
-        extra_fields.setdefault('is_superuser', False)
-        return self._create_user(email, displayName, password, **extra_fields)
-
-    def create_superuser(self, email, displayName, password=None, **extra_fields):
-        extra_fields.setdefault('is_staff', True)
-        extra_fields.setdefault('is_superuser', True)
-
-        if extra_fields.get('is_staff') is not True:
-            raise ValueError('Superuser must have is_staff=True.')
-        if extra_fields.get('is_superuser') is not True:
-            raise ValueError('Superuser must have is_superuser=True.')
-        return self._create_user(email, displayName, password, **extra_fields)
+    return '/'.join(['profileImages', str(instance.uuid), filename])
 
 class Author(AbstractBaseUser, PermissionsMixin):
     type = models.TextField(default="author")
@@ -68,17 +17,19 @@ class Author(AbstractBaseUser, PermissionsMixin):
     email = models.EmailField(unique=True)
     displayName = models.CharField(max_length=150)
     url = models.URLField(blank=True)
-    # host = models.URLField(blank=True )
+    host = models.URLField(blank=True)
     github = models.URLField()
+    profileImage = models.ImageField(blank=True, null=True, upload_to=upload_path)
     is_staff = models.BooleanField(default=False)
+    # is_auth = models.BooleanField(default=False) # ADMIN MUST MANUALLY AUTHENTICATE
 
     objects = AccountManager()
 
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['displayName']
 
-    # def get_full_name(self):
-    #     return self.name
-
-    # def get_short_name(self):
-    #     return self.name.split()[0]
+@receiver(post_delete, sender=Author)
+def recipe_image_delete(sender, instance, **kwargs):
+    if instance.profileImage:
+        instance.profileImage.delete(False)
+        

--- a/backend/author/serializers.py
+++ b/backend/author/serializers.py
@@ -8,7 +8,7 @@ import json
 class AuthorsSerializer(ModelSerializer):
     class Meta:
         model = Author
-        fields = ("type", "id", "host", "displayName", "url", "github", )
+        fields = ("type", "id", "host", "displayName", "url", "github", "profileImage")
 
     id = SerializerMethodField()
     host = SerializerMethodField()
@@ -34,14 +34,16 @@ class AuthorsSerializer(ModelSerializer):
 
         # Gather host
         # May require tweaking, full_path might not be the way
-        try:
-            host = HttpRequest.request.get_full_path()
+        request = self.context.get('listRequest')
+        if not request:
+            request = self.context.get('detailsRequest')
+        host = request.build_absolute_uri().split("authors")[0]
 
-        except:
+        if host == "":
             host = 'http://127.0.0.1:8000/'
 
         # Build URL
-        url = host + str(new_author.id)
+        url = host + "authors/" + str(new_author.uuid)
         
         # Update Author object
         new_author.url = url
@@ -55,13 +57,13 @@ class AuthorsSerializer(ModelSerializer):
         instance.github = validated_data.get('github', instance.github)
 
         # Handle image change (delete old off filebase)
-        # old_image = instance.profileImage
-        # instance.profileImage = validated_data.get(' profileImage', old_image)
-        # # check if new image was given
-        # if instance.profileImage != old_image:
-        #     # delete old image
-        #     if old_image and os.path.isfile(old_image.path):
-        #         os.remove(old_image.path)
+        old_image = instance.profileImage
+        instance.profileImage = validated_data.get('profileImage', old_image)
+        # check if new image was given
+        if instance.profileImage != old_image:
+            # delete old image
+            if old_image and os.path.isfile(old_image.path):
+                os.remove(old_image.path)
         instance.save()
         
         return instance 

--- a/backend/author/views.py
+++ b/backend/author/views.py
@@ -9,8 +9,9 @@ class AuthorList(APIView):
     
     # Get all Authors
     def get(self, request): 
-        # INCLUDE PERMISSION CHECKS BEFORE DOING THIS
-        # EX: return HttpResponse("You do not have permission to access this function.", status=403)
+        # if not request.user.is_authenticated:
+        #     return HttpResponse("You must be registered to access this function.", status = 401)
+
 
         all_authors = Author.objects.all()
         serializer = AuthorsSerializer(all_authors, many = True, context={'listRequest':request})
@@ -35,7 +36,10 @@ class AuthorDetails(APIView):
     
     # Get a specific author
     def get(self, request, author_id):
-        # INCLUDE PERMISSION CHECKS BEFORE DOING THIS
+        
+        # if not request.user.is_authenticated:
+        #     return HttpResponse("You must be registered to access this function.", status = 401)
+
         try:
             author = Author.objects.get(pk=author_id)
             serializer = AuthorsSerializer(author, context={'detailsRequest':request})
@@ -47,7 +51,8 @@ class AuthorDetails(APIView):
     # Update an author
     def post(self, request, author_id):
 
-        # INCLUDE PERMISSION CHECKS BEFORE DOING THIS
+        # if not request.user.is_authenticated:
+        #     return HttpResponse("You must be registered to access this function.", status = 401)
 
         try:
             author = Author.objects.get(pk=author_id)
@@ -56,23 +61,11 @@ class AuthorDetails(APIView):
 
         request_data = request.data.copy()
 
-        # Handle image change
-        # delete_image = False
-        # old_image = Author.profileImage
-        # new_image = request_data.get("profileImage")
-        # if new_image != old_image:
-        #     # set flag to delete image manually
-        #     delete_image = True
+
 
         serializer = AuthorsSerializer(author, data = request_data, partial=True, context={'detailsRequest':request})
         if serializer.is_valid():
             serializer.save()
-
-            # # delete image manually
-            # if delete_image:
-            #     if old_image and os.path.isfile(old_image.path):
-            #         os.remove(old_image.path)
-            #     author.save()
 
             return Response(serializer.data, status=200)
         else:
@@ -81,7 +74,8 @@ class AuthorDetails(APIView):
     # Delete an author
     def delete(self, request, author_id):
 
-        # INCLUDE PERMISSION CHECKS BEFORE DOING THIS
+        # if not request.user.is_authenticated:
+        #     return HttpResponse("You must be registered to access this function.", status = 401)
 
         try:
             author = Author.objects.get(pk=author_id)

--- a/backend/tests/test_author_api.py
+++ b/backend/tests/test_author_api.py
@@ -4,15 +4,22 @@ from django.http import HttpRequest
 import json
 from PIL import Image
 import tempfile
+import os
 
 class AuthorListTest(APITestCase):
     """Test the AuthorList class in views.py"""
 
     def setUp(self):
-        
+        image = Image.new('RGB', (123, 123))
+        temp = tempfile.NamedTemporaryFile(suffix='.jpg')
+        image.save(temp)
+        temp.seek(0)
+
+
         self.author_data = {
         "displayName" : "APITest",
         "github" : "https://github.com/CMPUT404W22-GroupProject/social-distribution",
+        "profileImage" : temp,
         }
     
     def testViewAuthors(self):
@@ -48,18 +55,24 @@ class AuthorDetailsTest(APITestCase):
 
     def setUp(self):
         
+        image = Image.new('RGB', (123, 123))
+        temp = tempfile.NamedTemporaryFile(suffix='.jpg')
+        image.save(temp)
+        temp.seek(0)
+        
         self.author_data = {
         "displayName" : "APITest",
         "github" : "https://github.com/CMPUT404W22-GroupProject/social-distribution",
+        "profileImage" : temp
         }
         
         # Get object and it's id
         response = self.client.post("/authors/", self.author_data)
-        self.author_id = response.data["id"]
+        self.author_id = response.data["id"].split("/")[-1]
         
         # What the host and url should be for automated test
-        self.host = 'http://127.0.0.1:8000/'
-        self.url = 'http://127.0.0.1:8000/{0}'.format(self.author_id)
+        self.host = 'http://testserver/'
+        self.url = 'http://testserver/authors/{0}'.format(self.author_id)
 
     def testAuthorDetails(self):
         """Test GET request for author's details"""
@@ -74,6 +87,7 @@ class AuthorDetailsTest(APITestCase):
         self.assertEqual(response.data["github"], self.author_data["github"])
         self.assertEqual(response.data["url"], self.url)
         self.assertEqual(response.data["host"], self.host)
+        self.assertNotEqual(response.data["profileImage"], None)
 
     def testAuthorUpdate(self):
         """Test POST request for author updating"""

--- a/backend/tests/test_author_model.py
+++ b/backend/tests/test_author_model.py
@@ -7,6 +7,7 @@ class AuthorModelTest(TestCase):
 
     def setUp(self):
         
+        # 127.0.0.1:8000 because there is no request being made via the server
         self.test_dict = {
              "host" : 'http://127.0.0.1:8000/',
              "displayName" : "testAuthor",
@@ -15,7 +16,7 @@ class AuthorModelTest(TestCase):
 
         self.author = Author.objects.create(**self.test_dict)
         
-        self.url = "http://127.0.0.1:8000/{0}".format(self.author.id)
+        self.url = "http://127.0.0.1:8000/{0}".format(self.author.uuid)
         self.author.url = self.url
 
     def testAuthorModel(self):


### PR DESCRIPTION
## Profile Image Storing

### Current Functionalities:
- Profile Images are stored at `./media/profileImages/{UUID}/`
- Images auto-delete when the author object is deleted
  - It should be noted the empty directory will **still** exist

### Current Drawbacks:
- Images are not deleted when replaced
  
  **Example:** User updates their profile picture and the new image is stored at the above location.
  The original image will also exist at this location, thus taking up unnecessary storage space.


## Sign Up Verification
### How it Works:

1. A user can sign up with email, password and profile name. 
- Their account will be created with the flag `is_auth` set to `False`
- The user will not be able to access any functionalities for the time being.
2. An admin can enter the Django Admin Panel and manually authenticate this new account.
- The admin can select the account and change it's `is_auth` flag to `True`
- The user will now be able to use all functionalities available to them. 

### How to Enable it:
1. Uncomment **line 26** in `author/managers.py`
2. Uncomment **line 24** in `author/models.py`

### Frontend Integration Possibility:
1. Superuser navigates to authentication page on frontend
2. Backend function pulls all users with `is_auth` set to `False`
3. Frontend displays this list of users
4. Superuser can choose who they would like to authenticate
5. Backend function sets `is_auth` to `True` for all chosen accounts