### PR TITLE
More team integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ To run the automated backend tests:
 1. Navigate to the `/backend` folder
 2. `python manage.py test tests`
 
+Deployment
+==========
+
+**Frontend**:
+
+https://bingbing10.herokuapp.com/
+
+**Backend**:
+
+https://cmput-404-w22-group-10-backend.herokuapp.com
+
+Video Demo
+==========
+
 Licensing
 =========
 

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -123,7 +123,8 @@ function Post({post, team, loggedInAuthor}){
                     //console.log(error)
                 }
             }
-            
+            // NOTE: THIS ENDPOINT IS NOT RESPONSIVE!!!!
+            // CANNOT FIND A /LIKES ENDPOINT THAT WORKS
             if ( postHostName === "tik-tak-toe-cmput404.herokuapp.com"){
                 try {
                         await axios.get(post.id + "/likes/", {
@@ -292,26 +293,18 @@ function Post({post, team, loggedInAuthor}){
             if (postHostName === "backend-404.herokuapp.com"){
                 if (!isLiked){
                     try {
-                        await axios.post(post.author.id + "/inbox/", remoteNewLike, {
+                        var inboxInfo = {
+                            "summary": loggedInAuthor.displayName + " likes your post",
+                            "type" : "Like",
+                            "author": loggedInAuthor,
+                            "object": post.id
+                          }  
+                        await axios.post(post.author.id + "/inbox/", inboxInfo, {
                             headers: {
                               'authorization': 'Basic ' + team4Authorization
                             }
-                          })
-                        .then((response) => {
-                            //console.log("THIS IS THE DATA",response.data);
-                            //setLikeId(response.data.id);
-                        });
+                          });
                     } catch (error) {
-                        ////console.log(error)
-                    }
-                } else {
-                    //console.log("DELETED LIKE");
-                    try {
-                        //await axios.delete( postPath + "/likes/" + likeId)
-                        //likeId is already full path
-                        //await axios.delete(likeId)
-                    } catch (error) {
-                        ////console.log(error)
                     }
                 }
             }
@@ -322,22 +315,8 @@ function Post({post, team, loggedInAuthor}){
                             headers: {
                               'authorization': 'Basic ' + team0Authorization
                             }
-                          })
-                        .then((response) => {
-                            //console.log("THIS IS THE DATA",response.data);
-                            //setLikeId(response.data.id);
                         });
-                    } catch (error) {
-                        ////console.log(error)
-                    }
-                } else {
-                    //console.log("DELETED LIKE");
-                    try {
-                        //await axios.delete( postPath + "/likes/" + likeId)
-                        //likeId is already full path
-                        //await axios.delete(likeId)
-                    } catch (error) {
-                        ////console.log(error)
+                    }catch (error){
                     }
                 }
             }

--- a/frontend/src/components/commentSection/CommentSection.jsx
+++ b/frontend/src/components/commentSection/CommentSection.jsx
@@ -291,6 +291,8 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
                         'Authorization': 'Basic ' + team4Authorization
                       }
                     })
+                    // The response from Team 0 has no valuable information
+                    // Only returns "author" and "type"
                   .then((response) => {
                   });
 

--- a/frontend/src/components/commentSection/CommentSection.jsx
+++ b/frontend/src/components/commentSection/CommentSection.jsx
@@ -70,8 +70,8 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
                     'Authorization': 'Basic ' + team4Authorization
                   }
                 });
-              //TODO: VERIFY RESPONSE FORMATTING
-              setBackendComments(result.data.comments.sort((p1, p2) => {
+              //Uses .items instead of .comments
+              setBackendComments(result.data.items.sort((p1, p2) => {
               return new Date(p2.published) - new Date(p1.published)
               }))
           } catch(error){
@@ -138,7 +138,7 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
                   }
                 });
               //TODO: VERIFY RESPONSE FORMATTING
-              setBackendComments(result.data.comments.sort((p1, p2) => {
+              setBackendComments(result.data.items.sort((p1, p2) => {
               return new Date(p2.published) - new Date(p1.published)
               }))
           } catch(error){
@@ -255,10 +255,18 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
             }
 
             if (postHostName === "backend-404.herokuapp.com"){
-                try {
-                    
-                    await axios.post(commentsId, newComment, {
-                        headers: {
+              // TEAM 4 says posting comments to their backend is not possible
+              // Thus this post to commentsId is useless
+              try {
+                var urlArray = commentsId.split("/");
+                var postId = urlArray[6]; // Get the post UUID
+                var postInfo =  {
+                  "contentType":"text/plain",
+                  "post_id": postId,
+                  "comment": text,
+                  }
+                    await axios.post(commentsId, postInfo, {  
+                      headers: {
                           'Authorization': 'Basic ' + team4Authorization
                         }
                       })
@@ -272,21 +280,33 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
                 }
                 try {
                     console.log("POST AUTHOR ID: ", postAuthorId);
-                    await axios.post(postAuthorId + "/inbox/", newComment, {
-                        headers: {
-                          'Authorization': 'Basic ' + team4Authorization
-                        }
-                      })
-                    .then((response) => {
-                    });
+                    // We cannot get the created comment ID because we cannot get a response BECAUSE the above POST is not allowed from remote nodes
+                    var inboxInfo = {
+                      "type": "comment",
+                      "id": commentsId,
+                      "author": loggedInAuthor,
+                  }
+                  await axios.post(postAuthorId + "/inbox/", inboxInfo, {
+                      headers: {
+                        'Authorization': 'Basic ' + team4Authorization
+                      }
+                    })
+                  .then((response) => {
+                  });
 
                 } catch (error) {
                     //console.log(error)
                 }
             }
             if (postHostName === "tik-tak-toe-cmput404.herokuapp.com"){
-                try {
-                    
+              // This also seems to be locked away from remote users
+              // Still give it the correct format as per their spec
+              var inboxInfo = {
+                "title": "New Comment",
+                "content": text,
+                "contentType": "text/plain"
+              }
+              try {
                     await axios.post(commentsId, newComment, {
                         headers: {
                           'Authorization': 'Basic ' + team0Authorization
@@ -301,14 +321,19 @@ const CommentSection = ({loggedInAuthor, commentsId, commentCount, postAuthorId,
                     //console.log(error)
                 }
                 try {
-                    console.log("POST AUTHOR ID: ", postAuthorId);
-                    await axios.post(postAuthorId + "/inbox/", newComment, {
-                        headers: {
-                          'Authorization': 'Basic ' + team0Authorization
-                        }
-                      })
-                    .then((response) => {
-                    });
+                  console.log("POST AUTHOR ID: ", postAuthorId);
+                  var inboxInfo = {
+                    "type": "comment",
+                    "id": commentsId,
+                    "author": loggedInAuthor,
+                  }
+                  await axios.post(postAuthorId + "/inbox/", inboxInfo, {
+                      headers: {
+                        'Authorization': 'Basic ' + team0Authorization
+                      }
+                    })
+                  .then((response) => {
+                  });
 
                 } catch (error) {
                     //console.log(error)

--- a/frontend/src/components/createPost/CreatePost.jsx
+++ b/frontend/src/components/createPost/CreatePost.jsx
@@ -176,7 +176,12 @@ function CreatePost({loggedInAuthor, loggedInAuthorId, loggedInAuthorFollowers})
                       status = response.status;
                       })
                   } else if (friendPathname === "backend-404.herokuapp.com"){
-                    await axios.post(friend.id + "/inbox/", newPost, {
+                    var inboxInfo = {
+                      "type":"post",
+                      "id": newPost["id"],
+                      "author": author.id 
+                    }  
+                    await axios.post(friend.id + "/inbox/", inboxInfo, {
                       headers: {
                         'authorization': 'Basic ' + team4Authorization
                       }
@@ -185,7 +190,12 @@ function CreatePost({loggedInAuthor, loggedInAuthorId, loggedInAuthorFollowers})
                       status = response.status;
                       })
                   } else if (friendPathname === "tik-tak-toe-cmput404.herokuapp.com"){
-                    await axios.post(friend.id + "/inbox/", newPost, {
+                    var inboxInfo = {
+                      "type":"post",
+                      "id": newPost["id"],
+                      "author": author.id 
+                    }  
+                    await axios.post(friend.id + "/inbox/", inboxInfo, {
                       headers: {
                         'authorization': 'Basic ' + team0Authorization
                       }
@@ -233,10 +243,29 @@ function CreatePost({loggedInAuthor, loggedInAuthorId, loggedInAuthorFollowers})
                         status = response.status;
                         })
                   } else if (followerPathname === "backend-404.herokuapp.com"){
-                    // TODO: VERIFY URL FORMATTING  
-                    await axios.post(follower.id + "/inbox/", newPost, {
+                    var inboxInfo = {
+                      "type":"post",
+                      "id": newPost["id"],
+                      "author": author.id 
+                    }  
+                    await axios.post(follower.id + "/inbox/", inboxInfo, {
                         headers: {
                           'authorization': 'Basic ' + team4Authorization
+                        }
+                      })
+                        .then((response) => {
+                        status = response.status;
+                        })
+                  }
+                  else if (followerPathname === "tik-tak-toe-cmput404.herokuapp.com"){
+                    var inboxInfo = {
+                      "type":"post",
+                      "id": newPost["id"],
+                      "author": author.id 
+                    }  
+                    await axios.post(follower.id + "/inbox/", inboxInfo, {
+                        headers: {
+                          'authorization': 'Basic ' + team0Authorization
                         }
                       })
                         .then((response) => {

--- a/frontend/src/components/feed/Feed.jsx
+++ b/frontend/src/components/feed/Feed.jsx
@@ -15,6 +15,7 @@ import { useContext } from "react";
 import PaginationControlled from "../paginationFeed";
 import ClearIcon from '@mui/icons-material/Clear';
 import Github from "../github/Github"
+import { CatchingPokemonSharp } from "@mui/icons-material"
 
 
 function Feed({id, feedType}){
@@ -54,36 +55,6 @@ function Feed({id, feedType}){
     //console.log("HUH WHAT: ", localStorage.getItem('user'))
     
     useEffect(() => {
-
-        const followTestSend = async () => {
-
-        var followTest = {
-            "type": "follow",
-            "summary": "I wanna follow you",
-            "actor": "http://backend-404.herokuapp.com/authors/044a48a4-36e4-4fa3-a9ee-c63b216fb8b2",
-            "object": "https://cmput-404-w22-group-10-backend.herokuapp.com/authors/4039f6a5-ab83-4a16-a0eb-377653be1937"
-            }
-        try {
-            await axios.post("https://cmput-404-w22-group-10-backend.herokuapp.com/authors/4039f6a5-ab83-4a16-a0eb-377653be1937" + "/inbox/", followTest, {
-                headers: {
-                  //'Authorization': 'token ' + team10token
-                  'Authorization': 'Basic ' + team10Authorization
-                }
-              })
-            .then((response) => {
-                //console.log("THIS IS THE DATA",response.data);
-                console.log("POSTED TO INBOX", response)
-            });
-        } catch (error) {
-            //console.log(error)
-        }
-    }
-        //followTestSend()
-    
-
-
-
-
 
         const getAuthorServer = async () => {
             
@@ -164,7 +135,7 @@ function Feed({id, feedType}){
                     const foreignAuthorURL = new URL(foreignAuthor.id);
                     const foreignAuthorPath = foreignAuthorURL.pathname;
                     if ("/authors/"+ urlAuthorId === foreignAuthorPath) {
-                        //console.log("TEAM 4 AUTHOR FOUND")
+                        // console.log("TEAM 4 AUTHOR FOUND")
                        setTeamServer("team4");
                        feedLoader("team4");
                        fetchUrlAuthorFollowers("team4");

--- a/frontend/src/components/followerList/followerList.jsx
+++ b/frontend/src/components/followerList/followerList.jsx
@@ -33,17 +33,24 @@ function FollowerList({profileId}) {
       const result = await axios.get(URL9 + "/authors/" + profileId + "/followers", {
         headers: {
           'Authorization': 'token ' + team9Authorization
-          //'Authorization': 'Basic ' + team10Authorization
         }});
       setForeignFollowers(...result.data.items)
       return 0
     }
 
     const fetchTeam4Followers = async () => {
-      const result = await axios.get(URL10 + "/authors/" + profileId + "/followers", {
+      const result = await axios.get(URL4 + "/authors/" + profileId + "/followers", {
         headers: {
-          'Authorization': 'token ' + team9Authorization
-          //'Authorization': 'Basic ' + team10Authorization
+          'Authorization': 'token ' + team4Authorization
+        }});
+      setForeignFollowers(...result.data.items)
+      return 0
+    }
+
+    const fetchTeam0Followers = async () => {
+      const result = await axios.get(URL0 + "/authors/" + profileId + "/followers", {
+        headers: {
+          'Authorization': 'token ' + team0Authorization
         }});
       setForeignFollowers(...result.data.items)
       return 0


### PR DESCRIPTION
Modified post request formatting for team 4 and team 0
Known issues:
- Team 4 & 0 do not allow a direct `POST` to their comments
- Team 4 inbox returns `400 BAD REQUEST` despite following their spec (for post, like and comment)
- Team 0 `GET` endpoint for `../likes` returns `500`

What I could get to work:
- `POST` to team 0 inbox (posts, comments, likes)
- `GET` all team 4 & 0 objects (excluding team 0 likes as mentioned above)

Changes made:
- Checked request formatting
- Checked response formatting

Important Notes:
- Will be double checking response handling for EVERYTHING
- @gurjogsingh if you wouldn't mind double checking WITH me that would be great
  - A fresh set of eyes will ensure I don't miss anything

EDIT 3/4/2022 @8:36pm:
- Can now `POST` to team 4 inbox for **posts only**